### PR TITLE
add excluded_field

### DIFF
--- a/src/aeon.erl
+++ b/src/aeon.erl
@@ -16,11 +16,13 @@
 	]).
 
 -opaque optional_field() :: optional_field.
+-opaque excluded_field() :: excluded_field.
 -opaque suppress(T) :: {suppress, T}.
 -opaque json_terms() :: json_terms.
 
 -export_type([
 	      optional_field/0,
+	      excluded_field/0,
 	      suppress/1,
 	      json_terms/0
 	     ]).

--- a/src/aeon_common.erl
+++ b/src/aeon_common.erl
@@ -5,6 +5,7 @@
 	 field_types/2,
 	 first_no_fail/2,
 	 is_optional_field/1,
+	 is_excluded_field/1,
 	 suppress_values/1
 	]).
 
@@ -54,4 +55,11 @@ is_optional_field({union, UTypes}) ->
 is_optional_field({type, {aeon, optional_field}}) ->
 	true;
 is_optional_field(_) ->
+	false.
+
+is_excluded_field({union, UTypes}) ->
+	lists:any(fun is_excluded_field/1, UTypes);
+is_excluded_field({type, {aeon, excluded_field}}) ->
+	true;
+is_excluded_field(_) ->
 	false.

--- a/src/aeon_to_jsx.erl
+++ b/src/aeon_to_jsx.erl
@@ -67,16 +67,21 @@ converted_value(Val, Type, Module) ->
 build_fieldmap(_Mod, _Rec, [], PropList) ->
 	PropList;
 build_fieldmap(Mod, Rec, [{FieldName, FieldType} | FieldInfo], PropList) ->
-	GetField = list_to_atom("#get-" ++ atom_to_list(element(1, Rec))),
-	Val = catching_convert(Mod:GetField(FieldName, Rec), FieldType, Mod),
-	case lists:member(Val, aeon_common:suppress_values(FieldType)) of
-		true ->
-			build_fieldmap(Mod, Rec, FieldInfo, PropList);
-		false ->
-			build_fieldmap(Mod,
-				       Rec,
-				       FieldInfo,
-				       [{atom_to_binary(FieldName, utf8),
-					 Val} | PropList])
-	end.
+    case aeon_common:is_excluded_field(FieldType) of
+        true ->
+            build_fieldmap(Mod, Rec, FieldInfo, PropList);
+        false ->
+            GetField = list_to_atom("#get-" ++ atom_to_list(element(1, Rec))),
+            Val = catching_convert(Mod:GetField(FieldName, Rec), FieldType, Mod),
+            case lists:member(Val, aeon_common:suppress_values(FieldType)) of
+                true ->
+                    build_fieldmap(Mod, Rec, FieldInfo, PropList);
+                false ->
+                    build_fieldmap(Mod,
+                        Rec,
+                        FieldInfo,
+                        [{atom_to_binary(FieldName, utf8),
+                            Val} | PropList])
+            end
+    end.
 


### PR DESCRIPTION
I have to define record like this sometimes

``` erlang
-record(user, {name, age, password}).
```

and I don't want to show `password` in JSON.

I just added `excluded_field` to `aeon` so that fields with `excluded_field` won't show in JSON.

Hope you like it   :joy: 
